### PR TITLE
fix: If there's a single search result you can't move from overview to detail

### DIFF
--- a/app/src/components/feature/advancedsearch/AdvancedSearch.component.jsx
+++ b/app/src/components/feature/advancedsearch/AdvancedSearch.component.jsx
@@ -113,7 +113,7 @@ function AdvancedSearch({
 
     useEffect(() => {
         if (store.workflow.shouldRunWorkflow) {
-            navigate(`/graph?study=${store.core.studyUuid}`);
+            navigate(`/graph/detail?study=${store.core.studyUuid}`);
         }
     }, [
         navigate,


### PR DESCRIPTION
Closes #156